### PR TITLE
Fix bug in export_dot function

### DIFF
--- a/src/pdag/_export/dot.py
+++ b/src/pdag/_export/dot.py
@@ -73,20 +73,36 @@ def export_dot(core_model: CoreModel, path: Path) -> None:  # noqa: C901, PLR091
 
     for name, collection in core_model.collections.items():
         graph.add_node(_mapping_node(collection))
+
+        input_params = set()
+        output_params = set()
+
         for item in collection.values():
             if isinstance(item, RelationshipABC):
                 for input_ref in item.iter_input_refs():
                     if isinstance(input_ref, ExecInfo):
-                        if input_ref.attribute not in added_exec_infos:
-                            graph.add_node(pydot.Node(input_ref.attribute, shape="diamond"))
-                            added_exec_infos.add(input_ref.attribute)
-                        graph.add_edge(pydot.Edge(input_ref.attribute, name))
+                        input_params.add(("execinfo", input_ref.attribute))
                     else:
-                        style = "dashed" if input_ref.previous else "solid"
-                        graph.add_edge(pydot.Edge(input_ref.name, name, style=style))
+                        input_params.add(("param", input_ref.name, input_ref.previous))
 
                 for output_ref in item.iter_output_refs():
-                    style = "dashed" if output_ref.next else "solid"
-                    graph.add_edge(pydot.Edge(name, output_ref.name, style=style))
+                    output_params.add(("param", output_ref.name, output_ref.next))
+
+        for i in input_params:
+            if i[0] == "execinfo":
+                attr = i[1]
+                if attr not in added_exec_infos:
+                    graph.add_node(pydot.Node(attr, shape="diamond"))
+                    added_exec_infos.add(attr)
+                graph.add_edge(pydot.Edge(attr, name))
+            else:
+                param = i[1]
+                style = "dashed" if i[2] else "solid"
+                graph.add_edge(pydot.Edge(param, name, style=style))
+
+        for o in output_params:
+            param = o[1]
+            style = "dashed" if o[2] else "solid"
+            graph.add_edge(pydot.Edge(name, param, style=style))
 
     graph.write(path, format="png")

--- a/src/pdag/_export/dot.py
+++ b/src/pdag/_export/dot.py
@@ -96,10 +96,13 @@ def export_dot(core_model: CoreModel, path: Path) -> None:  # noqa: C901, PLR091
                     graph.add_node(pydot.Node(attr, shape="diamond"))
                     added_exec_infos.add(attr)
                 graph.add_edge(pydot.Edge(attr, name))
-            else:
+            elif i[0] == "param":
                 param = i[1]
                 style = "dashed" if i[2] else "solid"
                 graph.add_edge(pydot.Edge(param, name, style=style))
+            else:
+                msg = f"Unknown type: {i[0]}"
+                raise ValueError(msg)
 
         for o in output_params:
             param = o[1]

--- a/src/pdag/_export/dot.py
+++ b/src/pdag/_export/dot.py
@@ -1,6 +1,6 @@
 from collections.abc import Hashable
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pydot
 

--- a/src/pdag/_export/dot.py
+++ b/src/pdag/_export/dot.py
@@ -74,8 +74,9 @@ def export_dot(core_model: CoreModel, path: Path) -> None:  # noqa: C901, PLR091
     for name, collection in core_model.collections.items():
         graph.add_node(_mapping_node(collection))
 
-        input_params: set[tuple[str, str, bool]] = set()
-        output_params: set[tuple[str, str, bool]] = set()
+        # The elements of the set are tuples of the form: (execinfo_or_param, name, is_delayed)
+        input_params: set[tuple[Literal["execinfo", "param"], str, bool]] = set()
+        output_params: set[tuple[Literal["execinfo", "param"], str, bool]] = set()
 
         for item in collection.values():
             if isinstance(item, RelationshipABC):

--- a/src/pdag/_export/dot.py
+++ b/src/pdag/_export/dot.py
@@ -74,14 +74,14 @@ def export_dot(core_model: CoreModel, path: Path) -> None:  # noqa: C901, PLR091
     for name, collection in core_model.collections.items():
         graph.add_node(_mapping_node(collection))
 
-        input_params = set()
-        output_params = set()
+        input_params: set[tuple[str, str, bool]] = set()
+        output_params: set[tuple[str, str, bool]] = set()
 
         for item in collection.values():
             if isinstance(item, RelationshipABC):
                 for input_ref in item.iter_input_refs():
                     if isinstance(input_ref, ExecInfo):
-                        input_params.add(("execinfo", input_ref.attribute))
+                        input_params.add(("execinfo", input_ref.attribute, False))
                     else:
                         input_params.add(("param", input_ref.name, input_ref.previous))
 

--- a/src/pdag/_export/dot.py
+++ b/src/pdag/_export/dot.py
@@ -73,20 +73,20 @@ def export_dot(core_model: CoreModel, path: Path) -> None:  # noqa: C901, PLR091
 
     for name, collection in core_model.collections.items():
         graph.add_node(_mapping_node(collection))
-        key, first_item = next(iter(collection.items()))
-        if isinstance(first_item, RelationshipABC):
-            for input_ref in first_item.iter_input_refs():
-                if isinstance(input_ref, ExecInfo):
-                    if input_ref.attribute not in added_exec_infos:
-                        graph.add_node(pydot.Node(input_ref.attribute, shape="diamond"))
-                        added_exec_infos.add(input_ref.attribute)
-                    graph.add_edge(pydot.Edge(input_ref.attribute, name))
-                else:
-                    style = "dashed" if input_ref.previous else "solid"
-                    graph.add_edge(pydot.Edge(input_ref.name, name, style=style))
+        for item in collection.values():
+            if isinstance(item, RelationshipABC):
+                for input_ref in item.iter_input_refs():
+                    if isinstance(input_ref, ExecInfo):
+                        if input_ref.attribute not in added_exec_infos:
+                            graph.add_node(pydot.Node(input_ref.attribute, shape="diamond"))
+                            added_exec_infos.add(input_ref.attribute)
+                        graph.add_edge(pydot.Edge(input_ref.attribute, name))
+                    else:
+                        style = "dashed" if input_ref.previous else "solid"
+                        graph.add_edge(pydot.Edge(input_ref.name, name, style=style))
 
-            for output_ref in first_item.iter_output_refs():
-                style = "dashed" if output_ref.next else "solid"
-                graph.add_edge(pydot.Edge(name, output_ref.name, style=style))
+                for output_ref in item.iter_output_refs():
+                    style = "dashed" if output_ref.next else "solid"
+                    graph.add_edge(pydot.Edge(name, output_ref.name, style=style))
 
     graph.write(path, format="png")


### PR DESCRIPTION
Closes #164 

This pull request includes changes to the `export_dot` function in the `src/pdag/_export/dot.py` file to ensure that all items in a collection are processed, not just the first one. The main changes involve iterating over all items in the collection and handling their input and output references.

`uv run pdag watch pdag.examples:TwoSquares squares.png` previously resulted in:
![image](https://github.com/user-attachments/assets/01369741-f08a-45f3-98c5-6b6bab5d7521)

After the fix, the output is now correct:
![image](https://github.com/user-attachments/assets/a8abe9e3-f43d-45fb-92e6-5843456df375)
