### PR TITLE
ci: create draft releases in GitHub workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,6 +121,7 @@ jobs:
       run: >-
         gh release create
         v${{ needs.create-tag.outputs.version }}
+        --draft
         --verify-tag
         --generate-notes
         --repo ${{ github.repository }}


### PR DESCRIPTION
Add the --draft flag to the release creation step in the release
workflow.